### PR TITLE
Nether Gold Deposit Drop Buff

### DIFF
--- a/src/main/resources/data/charm/loot_tables/blocks/nether_gold_deposit.json
+++ b/src/main/resources/data/charm/loot_tables/blocks/nether_gold_deposit.json
@@ -1,19 +1,62 @@
 {
-  "type": "minecraft:block",
-  "pools": [
-    {
-      "rolls": 1,
-      "entries": [
-        {
-          "type": "minecraft:item",
-          "name": "minecraft:gold_nugget"
-        }
-      ],
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ]
-    }
-  ]
+	"type": "minecraft:block",
+	"pools": [
+		{
+			"rolls": 1,
+			"entries": [
+				{
+					"type": "minecraft:alternatives",
+					"children": [
+						{
+							"type": "minecraft:item",
+							"conditions": [
+								{
+									"condition": "minecraft:match_tool",
+									"predicate":
+									{
+										"enchantments": [
+											{
+												"enchantment": "minecraft:silk_touch",
+												"levels":
+												{
+													"min": 1
+												}
+											}
+										]
+									}
+								}
+							],
+							"name": "charm:nether_gold_deposit"
+						},
+						{
+							"type": "minecraft:item",
+							"functions": [
+								{
+									"function": "minecraft:set_count",
+									"count":
+									{
+										"min": 5.0,
+										"max": 9.0,
+										"type": "minecraft:uniform"
+									}
+								},
+								{
+									"function": "minecraft:apply_bonus",
+									"enchantment": "minecraft:fortune",
+									"formula": "minecraft:uniform_bonus_count",
+									"parameters": {
+										"bonusMultiplier": 2
+									}
+								},
+								{
+									"function": "minecraft:explosion_decay"
+								}
+							],
+							"name": "minecraft:gold_nugget"
+						}
+					]
+				}
+			]
+		}
+	]
 }


### PR DESCRIPTION
With this change Nether Gold Ore deposit will now drop between 5 and 9 nuggets increased by 0-2 per fortune level. So on average without Fortune 7 nuggets and 10 with Fortune III.